### PR TITLE
fix dependency names (change hyphens to slashes)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,15 +26,11 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_range": ">= 1.0.0"
     },
     {
-      "name": "puppetlabs-java",
-      "version_range": ">= 1.3.0"
-    },
-    {
-      "name": "puppetlabs-java",
+      "name": "puppetlabs/java",
       "version_range": ">= 1.3.0"
     }
   ]


### PR DESCRIPTION
This fixes the dependency names to use `/` instead of `-`.  Incorrect dependency names throw warnings when running `puppet module list` (e.g. `Warning: Missing dependency 'puppetlabs-java':`).

I also removed the duplicate definition for `puppetlabs/java`.

_Note: I'm using puppet v3.7.5_
