### PR TITLE
add 'respawn' to init scripts by default to make services restart after ...

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,7 +13,7 @@
 #                 jvm_memory => '1024m'
 #               }
 #
-define storm::service($classname, $start = 'no', $jvm_memory = '768m', $opts = []) {
+define storm::service($classname, $start = 'no', $jvm_memory = '768m', $respawn = true, $opts = []) {
   require storm::install
 
   file { "/etc/init/storm-${name}.conf":
@@ -21,16 +21,16 @@ define storm::service($classname, $start = 'no', $jvm_memory = '768m', $opts = [
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    notify  => File["/etc/default/storm-${name}"], 
+    notify  => File["/etc/default/storm-${name}"],
   }
-  
+
   file { "/etc/default/storm-${name}":
     # require => Package['storm'],
     content => template('storm/default-service.erb'),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    notify  => Service["storm-${name}"], 
+    notify  => Service["storm-${name}"],
   }
 
   service { "storm-${name}":

--- a/templates/init-service.conf.erb
+++ b/templates/init-service.conf.erb
@@ -5,6 +5,10 @@ limit nofile 32768 32768
 start on (local-filesystems and net-device-up IFACE=eth0)
 stop on [!12345]
 
+<% if @respawn %>
+respawn
+<% end %>
+
 script
   # Source /etc/default
   . /etc/default/storm


### PR DESCRIPTION
Storm developers recommend running processes under supervision (e.g. `supervisord`);  however, since we're already using init scripts here to start the services upon boot, we can add the `respawn` command to the init scripts to automatically restart the services if there is an error.

Note that I made the `$respawn` parameter default to `true` in the `storm::service` definition, but it can be overridden if this isn't the desired effect.
