### PR TITLE
add module for logviewer service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,13 +60,16 @@ class storm (
   $drpc_servers = $storm::params::drpc_servers,
   $drpc_invocations_port = $storm::params::drpc_invocations_port,
 
+  $logviewer_port = $storm::params::logviewer_port,
+  $logviewer_childopts = $storm::params::logviewer_childopts,
+
   $supervisor_start_port = $storm::params::supervisor_start_port,
   $supervisor_workers = $storm::params::supervisor_workers,
   $supervisor_childopts = $storm::params::supervisor_childopts,
   $supervisor_enable = $storm::params::supervisor_enable,
 
   $worker_childopts = $storm::params::worker_childopts
-    
+
 ) inherits storm::params
 {
 }

--- a/manifests/logviewer.pp
+++ b/manifests/logviewer.pp
@@ -1,0 +1,25 @@
+# Class: storm::logviewer
+#
+# This module manages storm logviewer service
+#
+# Parameters: None
+#
+# Actions: None
+#
+# Requires: storm::install
+#
+# Sample Usage: include storm::logviewer
+#
+class storm::logviewer inherits storm {
+  require storm::install
+  require storm::config
+
+  # Install logviewer /etc/default
+  storm::service { 'logviewer':
+    start      => 'yes',
+    classname  => 'backtype.storm.daemon.logviewer',
+    jvm_memory => $storm::params::logviewer_mem,
+  }
+
+}
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,7 @@ class storm::params {
   $logviewer_port                       = hiera('logviewer_port', '8000')
   $logviewer_mem                        = hiera('logviewer_mem', '128m')
   $logviewer_childopts                  = hiera('logviewer_childopts', "-Xmx128m")
+  $logviewer_appender                   = hiera('logviewer_appender', "FILE")
 
   #_ SUPERVISOR _#
   $supervisor_mem                       = hiera('supervisor_mem', '1024m')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,6 +55,11 @@ class storm::params {
   $transactional_zookeeper_servers = hiera('transactional_zookeeper_servers', 'null')
   $transactional_zookeeper_port    = hiera('transactional_zookeeper_port', 'null')
 
+  #_ LOGVIEWER _#
+  $logviewer_port                       = hiera('logviewer_port', '8000')
+  $logviewer_mem                        = hiera('logviewer_mem', '128m')
+  $logviewer_childopts                  = hiera('logviewer_childopts', "-Xmx128m")
+
   #_ SUPERVISOR _#
   $supervisor_mem                       = hiera('supervisor_mem', '1024m')
   $supervisor_start_port                = hiera('supervisor_slots_start_port', '6700')

--- a/templates/init-service.conf.erb
+++ b/templates/init-service.conf.erb
@@ -15,7 +15,7 @@ script
   . /etc/default/storm-<%= @name %>
 
   # Set STORM Options
-  STORM_CMD="-classpath $STORM_CLASSPATH -Xms$STORM_<%= @name.upcase %>_JVM_MEMORY -Xmx$STORM_<%= @name.upcase %>_JVM_MEMORY -Djava.library.path=\"$JAVA_LIBRARY_PATH\" -Dstorm.options=\"$STORM_OPTIONS\" -Dstorm.home=$STORM_HOME -Dlogback.configurationFile=storm-logback.xml -Dlogfile.name=<%= @name %>.log $SUPERVISOR_JVM_OPTS <%= @classname %>"
+  STORM_CMD="-classpath $STORM_CLASSPATH -Xms$STORM_<%= @name.upcase %>_JVM_MEMORY -Xmx$STORM_<%= @name.upcase %>_JVM_MEMORY -Djava.library.path=\"$JAVA_LIBRARY_PATH\" -Dstorm.options=\"$STORM_OPTIONS\" -Dstorm.home=$STORM_HOME -Dlogback.configurationFile=storm-logback.xml -Dlogfile.name=<%= @name %>.log -Dstorm.log.dir=<%= @storm_logdir %> $SUPERVISOR_JVM_OPTS <%= @classname %>"
 
   if [ "x$ENABLE" = "xyes" ]; then
     exec start-stop-daemon --start --pidfile ${STORM_PID} --make-pidfile --chuid ${STORM_USER} --chdir ${STORM_HOME} --exec /usr/bin/java -- ${STORM_CMD}

--- a/templates/storm.yaml.erb
+++ b/templates/storm.yaml.erb
@@ -41,6 +41,10 @@ drpc.port: <%= scope.lookupvar('storm::drpc_port') %>
 drpc.invocations.port: <%= scope.lookupvar('storm::drpc_invocations_port') %>
 drpc.request.timeout.secs: <%= scope.lookupvar('storm::drpc_request_timeout_secs') %>
 
+#_ LOGVIEWER _#
+logviewer.port: <%= scope.lookupvar('storm::logviewer_port') %>
+logviewer.childopts: <%= scope.lookupvar('storm::logviewer_childopts') %>
+
 transactional.zookeeper.root: "<%= scope.lookupvar('storm::params::transactional_zookeeper_root') %>"
 transactional.zookeeper.servers: <%= scope.lookupvar('storm::params::transactional_zookeeper_servers') %>
 transactional.zookeeper.port: <%= scope.lookupvar('storm::params::transactional_zookeeper_port') %>

--- a/templates/storm.yaml.erb
+++ b/templates/storm.yaml.erb
@@ -44,6 +44,7 @@ drpc.request.timeout.secs: <%= scope.lookupvar('storm::drpc_request_timeout_secs
 #_ LOGVIEWER _#
 logviewer.port: <%= scope.lookupvar('storm::logviewer_port') %>
 logviewer.childopts: <%= scope.lookupvar('storm::logviewer_childopts') %>
+logviewer.appender.name: <%= scope.lookupvar('storm::logviewer_appender') %>
 
 transactional.zookeeper.root: "<%= scope.lookupvar('storm::params::transactional_zookeeper_root') %>"
 transactional.zookeeper.servers: <%= scope.lookupvar('storm::params::transactional_zookeeper_servers') %>


### PR DESCRIPTION
This PR adds a module for the `logviewer` service and the associated config params, and explicitly sets the `storm.log.dir` command line option (because the supervisor service doesn't use the `storm_logdir` set up in the logback config -- without setting it explicitly, the worker logs get written to `<STORM_HOME>/logs`).
