### PR TITLE
Update/fix storm install exec to only run when necessary and allow for upgrades

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class storm::install (
     $mirror = $storm::params::storm_mirror,
 ) inherits storm {
     require java
-    
+
     package { 'wget': ensure => [latest,installed] }
     package { 'rsync': ensure => [latest,installed] }
 
@@ -66,7 +66,7 @@ class storm::install (
 
     exec { 'storm-install':
         command => "rsync -auzp --exclude=\"src\" ${untardir}/ ${homedir}",
-        creates => "${homedir}/storm-${version}.jar",
+        creates => "${homedir}/lib/storm-core-${version}.jar",
         path => ['/usr/bin', '/usr/sbin', '/sbin', 'bin'],
         # notify => Service['storm'],
         require => [File[$homedir], Package['rsync']],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,7 +65,7 @@ class storm::install (
     }
 
     exec { 'storm-install':
-        command => "rsync -auzp --exclude=\"src\" ${untardir}/ ${homedir}",
+        command => "rsync -auzp --delete --exclude=\"src\" ${untardir}/ ${homedir}",
         creates => "${homedir}/lib/storm-core-${version}.jar",
         path => ['/usr/bin', '/usr/sbin', '/sbin', 'bin'],
         # notify => Service['storm'],


### PR DESCRIPTION
The `creates` param for the `storm-install` exec was set to a file that never gets created, so puppet agent runs always run the `storm-install` exec and result in a "modified" state (I'm using Puppet Dashboard, so extraneous "modified" states can be misleading in this case).  

Also, I added `--delete` to the `rsync` command to delete any files in the destination directory that shouldn't be there.  The point of this is to allow for upgrades by removing old extraneous files rather than just adding new version files in with old versions. 

_Admittedly, I've only tested these updates after the module already installed storm once, so I haven't actually tried upgrading... but these changes make sense to me and should not cause any unintended consequences.  You may want to review for yourself to double-check me._
