### PR TITLE
Fix for topology_kryo_register variable and init-service.conf.erb

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,7 +83,7 @@ class storm::params {
   $zmq_linger_millis = hiera('zmq_linger_millis', '5000')
 
   #_ TOPOLOGY _#
-  $topology_kryo_register                      = hiera_array('topology_kryo.register', [''])
+  $topology_kryo_register                      = hiera_array('topology_kryo_register', [''])
   $topology_debug                              = hiera('topology_debug', 'false')
   $topology_optimize                           = hiera('topology_optimize', 'true')
   $topology_workers                            = hiera('topology_workers', '1')

--- a/templates/init-service.conf.erb
+++ b/templates/init-service.conf.erb
@@ -15,7 +15,7 @@ script
   . /etc/default/storm-<%= @name %>
 
   # Set STORM Options
-  STORM_CMD="-classpath $STORM_CLASSPATH -Xms$STORM_<%= @name.upcase %>_JVM_MEMORY -Xmx$STORM_<%= @name.upcase %>_JVM_MEMORY -Djava.library.path=\"$JAVA_LIBRARY_PATH\" -Dstorm.options=\"$STORM_OPTIONS\" -Dstorm.home=$STORM_HOME -Dlogback.configurationFile=/etc/storm/storm-logback.xml -Dlogfile.name=<%= @name %>.log -Dstorm.log.dir=<%= @storm_logdir %> $SUPERVISOR_JVM_OPTS <%= @classname %>"
+  STORM_CMD="-classpath $STORM_CLASSPATH -Xms$STORM_<%= @name.upcase %>_JVM_MEMORY -Xmx$STORM_<%= @name.upcase %>_JVM_MEMORY -Djava.library.path=\"$JAVA_LIBRARY_PATH\" -Dstorm.options=\"$STORM_OPTIONS\" -Dstorm.home=$STORM_HOME -Dlogback.configurationFile=/etc/storm/storm-logback.xml -Dlogfile.name=<%= @name %>.log $SUPERVISOR_JVM_OPTS <%= @classname %>"
 
   if [ "x$ENABLE" = "xyes" ]; then
     exec start-stop-daemon --start --pidfile ${STORM_PID} --make-pidfile --chuid ${STORM_USER} --chdir ${STORM_HOME} --exec /usr/bin/java -- ${STORM_CMD}

--- a/templates/init-service.conf.erb
+++ b/templates/init-service.conf.erb
@@ -15,7 +15,7 @@ script
   . /etc/default/storm-<%= @name %>
 
   # Set STORM Options
-  STORM_CMD="-classpath $STORM_CLASSPATH -Xms$STORM_<%= @name.upcase %>_JVM_MEMORY -Xmx$STORM_<%= @name.upcase %>_JVM_MEMORY -Djava.library.path=\"$JAVA_LIBRARY_PATH\" -Dstorm.options=\"$STORM_OPTIONS\" -Dstorm.home=$STORM_HOME -Dlogback.configurationFile=storm-logback.xml -Dlogfile.name=<%= @name %>.log -Dstorm.log.dir=<%= @storm_logdir %> $SUPERVISOR_JVM_OPTS <%= @classname %>"
+  STORM_CMD="-classpath $STORM_CLASSPATH -Xms$STORM_<%= @name.upcase %>_JVM_MEMORY -Xmx$STORM_<%= @name.upcase %>_JVM_MEMORY -Djava.library.path=\"$JAVA_LIBRARY_PATH\" -Dstorm.options=\"$STORM_OPTIONS\" -Dstorm.home=$STORM_HOME -Dlogback.configurationFile=/etc/storm/storm-logback.xml -Dlogfile.name=<%= @name %>.log -Dstorm.log.dir=<%= @storm_logdir %> $SUPERVISOR_JVM_OPTS <%= @classname %>"
 
   if [ "x$ENABLE" = "xyes" ]; then
     exec start-stop-daemon --start --pidfile ${STORM_PID} --make-pidfile --chuid ${STORM_USER} --chdir ${STORM_HOME} --exec /usr/bin/java -- ${STORM_CMD}


### PR DESCRIPTION
A couple changes I made in order to get this puppet module working for me when installing storm 0.9.6

The topology_kryo_register variable was strange to me because I can't find anywhere that it's being used. I left it in anyway and changed the hiera_array call.

The logback file wasn't being used used in the service file with the full path and logging had broken.
